### PR TITLE
Add ability to admin a user

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,17 +34,18 @@ class UsersController < ApplicationController
 
 
  def update
-   # puts params
+  @user = User.find_by_id params[:id]
+  if can? :manage, @user
+    user_params = params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation, :admin)
+  else
+    user_params = params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
+  end
 
-   @user = User.find_by_id params[:id]
-
-   user_params = params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
-
-   if @user.update user_params
-     redirect_to root_path, notice: "Account Updated"
-   else
-     render :edit
-   end
+  if @user.update user_params
+    redirect_to root_path, notice: "Account Updated"
+  else
+    render :edit
+  end
 
  end
 

--- a/app/views/admin/users.html.erb
+++ b/app/views/admin/users.html.erb
@@ -39,7 +39,11 @@
     <tbody>
       <% @users.each do |u| %>
       <tr>
-        <td><%= u.first_name %> <%= u.last_name %></td>
+        <td>
+          <%= u.first_name %> <%= u.last_name %>
+          <% if u.admin? %>
+            <i class="fa fa-key" aria-hidden="true"></i>
+          <% end %></td>
         <td><%= u.email %></td>
         <td><% if u.organization %>
         <%= u.organization.name %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -7,29 +7,14 @@
 
 <br>
 <br>
-<%= form_for @user, class: "form-horizontal" do |f|%>
-  <div class="form-group row">
-    <%= f.label :first_name, class: "col-md-2 control-label" %>
-    <div class="col-md-8">
-      <%= f.text_field :first_name %>
-    </div>
-  </div>
-
-  <div class="form-group row">
-    <%= f.label :last_name, class: "col-md-2 control-label" %>
-    <div class="col-md-8">
-      <%= f.text_field :last_name %>
-    </div>
-  </div>
-
-  <div class="form-group row">
-    <%= f.label :email, class: "col-md-2 control-label" %>
-    <div class="col-md-8">
-      <%= f.email_field :email %>
-    </div>
-  </div>
-
-  <div class="form-group row">
-    <%= f.submit "Update User", class: "btn btn-primary col-md-offset-2" %>
-  </div>
-<% end  %>
+<div class="col-lg-3 col-md-4 col-xs-8">
+  <%= simple_form_for @user, class: "form-horizontal" do |f|%>
+      <%= f.input :first_name%>
+      <%= f.input :last_name %>
+      <%= f.input :email %>
+      <% if (can? :manage, @user) && (@user.id != current_user.id) %>
+        <%= f.input :admin, label: "Admin",as: :boolean, checked_value: true, unchecked_value: false %>
+      <% end %>
+      <%= f.submit "Update User", class: "btn btn-primary" %>
+  <% end  %>
+</div>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
+require 'pry'
 
 RSpec.describe UsersController, type: :controller do
+  let (:admin_user) { FactoryGirl.create(:admin) }
+  let (:user) { FactoryGirl.create(:user) }
   describe "#new" do
     it "renders the new template" do
       get :new
@@ -61,5 +64,46 @@ RSpec.describe UsersController, type: :controller do
       end
     end
 
+  end
+
+
+  describe "#edit" do
+    render_views
+    describe "as a mortal" do
+    before { login(user) }
+      it "doesn't show the option make the user an admin" do
+        get :edit, id: user.id
+        expect(response.body).not_to include("Admin")
+      end
+    end
+    describe "as an admin" do
+    before { login(admin_user) }
+      it "shows the option to make the user an admin" do
+        get :edit, id: user.id
+        expect(response.body).to include("Admin")
+      end
+    end
+  end
+
+  describe "#update" do
+
+    describe "as a mortal" do
+      before do
+        login(user)
+        patch :update, id: user.id, user: {admin: true}
+      end
+      it "mortals update their own status to admin" do
+        expect(user.reload.admin).to eq(false)
+      end
+    end
+    describe "as administrators" do
+      before do
+        login(admin_user)
+        patch :update, id: user.id, user: {admin: true}
+      end
+      it "administrators can make more administrators" do
+        expect(user.reload.admin).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
An admin can make other users admin via the user edit page on the admin area.
The view only displays such option if the current user is admin.

We include the following tests: 
- A regular user can not make himself or other user an admin
- An admin can make other users admins
