### PR TITLE
Team 1 - Fix add event feature for admin. Change flash: to notice:

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,7 @@ class EventsController < ApplicationController
   def create
     @event = Event.new(event_params)
     if @event.save
-      redirect_to admin_events_path, flash: "Event Added"
+      redirect_to admin_events_path, notice: "Event Added"
     else
       redirect_to admin_events_path, alert: "Event Not Added"
     end
@@ -16,7 +16,7 @@ class EventsController < ApplicationController
   def destroy
     @event = Event.find params[:id]
     if @event.destroy
-      redirect_to admin_events_path, flash: "Event Removed"
+      redirect_to admin_events_path, notice: "Event Removed"
     else
       redirect_to admin_events_path, alert: "Event Not Removed"
     end


### PR DESCRIPTION
On the redirects there was flash: "Event added" this would throw an error because flash: is an invalid key. I changed it to notice: instead
